### PR TITLE
Adjust WhatsApp Reminders and Fix Calendar Modal State

### DIFF
--- a/src/app/api/webhook/whatsapp/reminders/route.ts
+++ b/src/app/api/webhook/whatsapp/reminders/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/supabase/admin';
-import { sendWhatsAppReminder } from '@/supabase/whatsapp';
+import {
+  sendWhatsAppReminder,
+  sendWhatsAppReengagementReminder,
+} from '@/supabase/whatsapp';
 import { APPOINTMENT_DATABASE } from '@/types/GlobalTypes';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -20,55 +23,140 @@ export async function GET(request: Request) {
   }
 
   const supabase = createAdminClient();
+  const today = dayjs();
+  const dayOfWeek = today.day(); // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
 
-  // Use date-only format (works with Supabase timestamp columns)
-  const tomorrow = dayjs().utc().add(1, 'day');
-  const tomorrowDate = tomorrow.format('YYYY-MM-DD');
-  const nextDay = tomorrow.add(1, 'day').format('YYYY-MM-DD');
-
-  const { data: appointments, error } = await supabase
-    .from(APPOINTMENT_DATABASE)
-    .select(
-      `
-      *,
-      patient (
-        id,
-        first_name,
-        last_name,
-        phone
-      )
-    `
-    )
-    .gte('start_time', tomorrowDate)
-    .lt('start_time', nextDay) // Use lt (less than) for the next day
-    .eq('status', 'pending');
-
-  if (error) {
-    console.error('Supabase error:', error);
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  // Send reminders...
   const results = [];
   const concurrencyLimit = 10;
 
-  if (appointments && appointments.length > 0) {
-    for (let i = 0; i < appointments.length; i += concurrencyLimit) {
-      const chunk = appointments.slice(i, i + concurrencyLimit);
-      const chunkPromises = chunk.map(async (app) => {
-        const phone = app.phone_number || app.patient?.phone;
-        if (phone) {
-          const time = dayjs(app.start_time).format('HH:mm');
-          const patientName =
-            `${app.patient?.first_name || ''} ${app.patient?.last_name || ''}`.trim();
-          const result = await sendWhatsAppReminder(phone, patientName, time);
-          return { appointmentId: app.id, result };
-        }
-        return { appointmentId: app.id, result: 'No phone number' };
-      });
+  // Sunday (0) to Thursday (4) - Upcoming Appointment Reminders
+  if (dayOfWeek >= 0 && dayOfWeek <= 4) {
+    const tomorrow = dayjs().utc().add(1, 'day');
+    const tomorrowDate = tomorrow.format('YYYY-MM-DD');
+    const nextDay = tomorrow.add(1, 'day').format('YYYY-MM-DD');
 
-      const chunkResults = await Promise.all(chunkPromises);
-      results.push(...chunkResults);
+    const { data: appointments, error } = await supabase
+      .from(APPOINTMENT_DATABASE)
+      .select(
+        `
+        *,
+        patient (
+          id,
+          first_name,
+          last_name,
+          phone
+        )
+      `
+      )
+      .gte('start_time', tomorrowDate)
+      .lt('start_time', nextDay)
+      .eq('status', 'pending');
+
+    if (error) {
+      console.error('Supabase error:', error);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (appointments && appointments.length > 0) {
+      for (let i = 0; i < appointments.length; i += concurrencyLimit) {
+        const chunk = appointments.slice(i, i + concurrencyLimit);
+        const chunkPromises = chunk.map(async (app) => {
+          const phone = app.phone_number || app.patient?.phone;
+          if (phone) {
+            const time = dayjs(app.start_time).format('HH:mm');
+            const patientName =
+              `${app.patient?.first_name || ''} ${app.patient?.last_name || ''}`.trim();
+            const result = await sendWhatsAppReminder(phone, patientName, time);
+            return { appointmentId: app.id, type: 'reminder', result };
+          }
+          return { appointmentId: app.id, type: 'reminder', result: 'No phone number' };
+        });
+
+        const chunkResults = await Promise.all(chunkPromises);
+        results.push(...chunkResults);
+      }
+    }
+  }
+
+  // Saturday (6) - Re-engagement (6 months since last visit)
+  if (dayOfWeek === 6) {
+    const sixMonthsAgoStart = dayjs()
+      .subtract(187, 'day')
+      .format('YYYY-MM-DD');
+    const sixMonthsAgoEnd = dayjs()
+      .subtract(180, 'day')
+      .format('YYYY-MM-DD');
+
+    // This query is slightly more complex. We want patients whose last appointment was 6 months ago.
+    // For simplicity, we can fetch patients who had an appointment in that window
+    // and then check if they have any newer appointments.
+
+    const { data: candidates, error: candidateError } = await supabase
+      .from(APPOINTMENT_DATABASE)
+      .select(`
+        patient_id,
+        patient:patient_id (
+          id,
+          first_name,
+          last_name,
+          phone
+        )
+      `)
+      .gte('start_time', sixMonthsAgoStart)
+      .lte('start_time', sixMonthsAgoEnd)
+      .eq('status', 'confirmed');
+
+    if (candidateError) {
+      console.error('Supabase error:', candidateError);
+      return NextResponse.json({ error: candidateError.message }, { status: 500 });
+    }
+
+    const uniquePatientIds = Array.from(
+      new Set(candidates?.map((c) => c.patient_id))
+    );
+
+    if (uniquePatientIds.length > 0) {
+      // Find all patients who HAVE future appointments
+      const { data: patientsWithFutureApps, error: futureError } = await supabase
+        .from(APPOINTMENT_DATABASE)
+        .select('patient_id')
+        .in('patient_id', uniquePatientIds)
+        .gt('start_time', sixMonthsAgoEnd);
+
+      if (!futureError) {
+        const idsWithFutureApps = new Set(
+          patientsWithFutureApps?.map((a) => a.patient_id)
+        );
+        const targetPatientIds = uniquePatientIds.filter(
+          (id) => !idsWithFutureApps.has(id)
+        );
+
+        for (let i = 0; i < targetPatientIds.length; i += concurrencyLimit) {
+          const chunk = targetPatientIds.slice(i, i + concurrencyLimit);
+          const chunkPromises = chunk.map(async (patientId) => {
+            const candidate = candidates?.find((c) => c.patient_id === patientId);
+            const patient = candidate?.patient as unknown as {
+              id: number;
+              first_name: string;
+              last_name: string;
+              phone: string;
+            };
+            if (patient && patient.phone) {
+              const patientName =
+                `${patient.first_name || ''} ${patient.last_name || ''}`.trim();
+              const result = await sendWhatsAppReengagementReminder(
+                patient.phone,
+                patientName
+              );
+              return { patientId, type: 're-engagement', result };
+            }
+            return { patientId, type: 're-engagement', result: 'No phone' };
+          });
+
+          const chunkResults = await Promise.all(chunkPromises);
+          results.push(...chunkResults);
+        }
+      }
     }
   }
 

--- a/src/components/components/Modals/AppointmentModal.tsx
+++ b/src/components/components/Modals/AppointmentModal.tsx
@@ -148,6 +148,43 @@ export default function AppointmentModal({
     }
   }, [selectedPatientId, startTime, patients, appointment]);
 
+  useEffect(() => {
+    const initial = appointment?.start_time
+      ? dayjs(appointment.start_time)
+      : selectedDate
+        ? dayjs(selectedDate)
+        : dayjs();
+    setStartTime(
+      initial.isValid()
+        ? initial.format('YYYY-MM-DDTHH:mm')
+        : dayjs().format('YYYY-MM-DDTHH:mm')
+    );
+  }, [selectedDate, appointment]);
+
+  useEffect(() => {
+    if (appointment?.end_time) {
+      const initial = dayjs(appointment.end_time);
+      if (initial.isValid()) {
+        setEndTime(initial.format('YYYY-MM-DDTHH:mm'));
+        return;
+      }
+    }
+
+    const patient = patients.find((p) => p.id === selectedPatientId);
+    let duration = 30;
+    if (patient) {
+      const birthdate = patient.birthdate ? dayjs(patient.birthdate) : null;
+      const isAdult = birthdate
+        ? dayjs().diff(birthdate, 'year') >= 18
+        : true;
+      duration = isAdult ? 60 : 30;
+    }
+
+    setEndTime(
+      dayjs(startTime).add(duration, 'minute').format('YYYY-MM-DDTHH:mm')
+    );
+  }, [selectedDate, appointment, selectedPatientId, patients, startTime]);
+
   const saveAppointment = async () => {
     try {
       const formData = new FormData();

--- a/src/components/components/Wrappers/PatientClientWrapper.tsx
+++ b/src/components/components/Wrappers/PatientClientWrapper.tsx
@@ -14,7 +14,11 @@ import { useDictionary } from '../../providers/DictionaryProvider';
 import TreatmentsOverview, {
   TreatmentsOverviewProps,
 } from '../Wrappers/TreatmentsOverview';
-import { LoadRowsFunction, PatientCategory, SupabaseArray } from '@/types/GeneralTypes';
+import {
+  LoadRowsFunction,
+  PatientCategory,
+  SupabaseArray,
+} from '@/types/GeneralTypes';
 import { EditableAppointmentTable } from '../Tables/EditableTable';
 import { Button } from '@/components/atoms/Button';
 import { useDialog } from '@/components/providers/DialogProvider';
@@ -87,97 +91,99 @@ export default function PatientClientWrapper({
           />
         </Tab>
         <Tab title={appointmentsHeadline ?? ''}>
-          <div className='bg-background rounded-lg p-5 md:p-10'>
-            <div className='border-font/20 mb-2 flex flex-row border-b-2 border-dashed pb-2'>
-              <div className='flex flex-1 items-center'>
-                <Headline
-                  headline={appointmentsHeadline ?? ''}
-                  className='!mb-0 !text-2xl'
-                />
-              </div>
-              <div className='flex h-fit flex-1 justify-end'>
-                <Button
-                  label={addAppointment || 'Add Appointment'}
-                  iconName='event'
-                  onClick={() =>
-                    handleClick(
-                      <AppointmentModal
-                        patients={[
-                          {
-                            id: patient.id as number,
-                            first_name: patient.first_name || '',
-                            last_name: patient.last_name || '',
-                            phone: patient.phone || '',
-                            birthdate: patient.birthdate || null,
-                          },
-                        ]}
-                        patientId={patientID}
-                        onSave={() => router.refresh()}
-                        initialAppointments={
-                          appointments as {
-                            id: number;
-                            start_time: string;
-                            end_time: string;
-                          }[]
-                        }
-                      />,
-                      addAppointment || 'Add Appointment'
-                    )
+          <EditableAppointmentTable
+            data={appointments}
+            loadRows={loadAppointmentRows}
+            onEditClick={(rowData) =>
+              handleClick(
+                <AppointmentModal
+                  appointment={{
+                    id: Number(rowData.id),
+                    patient_id: patientID,
+                    start_time: rowData.start_time,
+                    end_time: rowData.end_time,
+                    phone_number: rowData.phone_number,
+                    patient: {
+                      id: patient.id as number,
+                      first_name: patient.first_name || '',
+                      last_name: patient.last_name || '',
+                      phone: patient.phone || '',
+                      birthdate: patient.birthdate || null,
+                    },
+                  }}
+                  patients={[
+                    {
+                      id: patient.id as number,
+                      first_name: patient.first_name || '',
+                      last_name: patient.last_name || '',
+                      phone: patient.phone || '',
+                      birthdate: patient.birthdate || null,
+                    },
+                  ]}
+                  patientId={patientID}
+                  onSave={() => router.refresh()}
+                  initialAppointments={
+                    appointments as {
+                      id: number;
+                      start_time: string;
+                      end_time: string;
+                    }[]
                   }
-                />
-              </div>
-            </div>
-            <EditableAppointmentTable
-              data={appointments}
-              loadRows={loadAppointmentRows}
-              onEditClick={(rowData) =>
-                handleClick(
-                  <AppointmentModal
-                    appointment={{
-                      id: Number(rowData.id),
-                      patient_id: patientID,
-                      start_time: rowData.start_time,
-                      end_time: rowData.end_time,
-                      phone_number: rowData.phone_number,
-                      patient: {
-                        id: patient.id as number,
-                        first_name: patient.first_name || '',
-                        last_name: patient.last_name || '',
-                        phone: patient.phone || '',
-                        birthdate: patient.birthdate || null,
-                      },
-                    }}
-                    patients={[
-                      {
-                        id: patient.id as number,
-                        first_name: patient.first_name || '',
-                        last_name: patient.last_name || '',
-                        phone: patient.phone || '',
-                        birthdate: patient.birthdate || null,
-                      },
-                    ]}
-                    patientId={patientID}
-                    onSave={() => router.refresh()}
-                    initialAppointments={
-                      appointments as {
-                        id: number;
-                        start_time: string;
-                        end_time: string;
-                      }[]
-                    }
-                  />,
-                  editAppointmentText || 'Edit Appointment'
-                )
-              }
-              deleteAction={async (id) => {
-                await deleteAppointment(id);
-                router.refresh();
-              }}
-              editMessage={editAppointmentText ?? undefined}
-              deleteMessage={deleteAppointmentText ?? undefined}
-              deleteDialogMessage={deleteAppointmentMessage ?? undefined}
-            />
-          </div>
+                />,
+                editAppointmentText || 'Edit Appointment'
+              )
+            }
+            deleteAction={async (id) => {
+              await deleteAppointment(id);
+              router.refresh();
+            }}
+            editMessage={editAppointmentText ?? undefined}
+            deleteMessage={deleteAppointmentText ?? undefined}
+            deleteDialogMessage={deleteAppointmentMessage ?? undefined}
+            tableHeader={
+              <>
+                <div className='border-font/20 mb-2 flex flex-row border-b-2 border-dashed pb-2'>
+                  <div className='flex flex-1 items-center'>
+                    <Headline
+                      headline={appointmentsHeadline ?? ''}
+                      className='!mb-0 !text-2xl'
+                    />
+                  </div>
+                  <div className='flex h-fit flex-1 justify-end'>
+                    <Button
+                      label={addAppointment || 'Add Appointment'}
+                      iconName='event'
+                      onClick={() =>
+                        handleClick(
+                          <AppointmentModal
+                            patients={[
+                              {
+                                id: patient.id as number,
+                                first_name: patient.first_name || '',
+                                last_name: patient.last_name || '',
+                                phone: patient.phone || '',
+                                birthdate: patient.birthdate || null,
+                              },
+                            ]}
+                            patientId={patientID}
+                            onSave={() => router.refresh()}
+                            initialAppointments={
+                              appointments as {
+                                id: number;
+                                start_time: string;
+                                end_time: string;
+                              }[]
+                            }
+                          />,
+                          addAppointment || 'Add Appointment'
+                        )
+                      }
+                    />
+                  </div>
+                </div>
+              </>
+            }
+          />
         </Tab>
       </Tabs>
     </>

--- a/src/components/molecules/EditForm.tsx
+++ b/src/components/molecules/EditForm.tsx
@@ -30,7 +30,9 @@ export default function EditForm({
   notificationMessage,
   ...rest
 }: EditFormProps) {
-  const dictionary = useDictionary(); const { save, cancel } = dictionary?.edit || {}; const { errorMessage, successMessage } = dictionary?.feedback || {};
+  const dictionary = useDictionary();
+  const { save, cancel } = dictionary?.edit || {};
+  const { errorMessage, successMessage } = dictionary?.feedback || {};
 
   const { handleClick, closeDialog, showFeedback } = useDialog();
 
@@ -127,7 +129,9 @@ export default function EditForm({
 }
 
 export function EditPatientForm(props: BaseEditFormProps) {
-  const dictionary = useDictionary(); const { addPatient, editPatient } = dictionary?.edit || {}; const { patientAdultNotification } = dictionary?.form || {};
+  const dictionary = useDictionary();
+  const { addPatient, editPatient } = dictionary?.edit || {};
+  const { patientAdultNotification } = dictionary?.form || {};
 
   return (
     <EditForm
@@ -141,7 +145,8 @@ export function EditPatientForm(props: BaseEditFormProps) {
 }
 
 export function EditTreatmentForm(props: BaseEditFormProps) {
-  const dictionary = useDictionary(); const { addTreatment, editTreatment } = dictionary?.edit || {};
+  const dictionary = useDictionary();
+  const { addTreatment, editTreatment } = dictionary?.edit || {};
 
   return (
     <EditForm
@@ -154,7 +159,8 @@ export function EditTreatmentForm(props: BaseEditFormProps) {
 }
 
 export function EditTODOForm(props: BaseEditFormProps) {
-  const dictionary = useDictionary(); const { addTODOItem, editTODOItem } = dictionary?.todo || {};
+  const dictionary = useDictionary();
+  const { addTODOItem, editTODOItem } = dictionary?.todo || {};
 
   return (
     <EditForm

--- a/src/components/providers/DialogProvider.tsx
+++ b/src/components/providers/DialogProvider.tsx
@@ -65,7 +65,7 @@ export default function DialogProvider({
     >
       <Dialog
         isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
+        onClose={closeDialog}
         headline={headline}
         className={className}
       >

--- a/src/supabase/whatsapp.ts
+++ b/src/supabase/whatsapp.ts
@@ -109,3 +109,55 @@ export async function sendWhatsAppReminder(
     console.error('WhatsApp Template API call failed:', error);
   }
 }
+
+/**
+ * Sends a re-engagement message to patients who haven't visited in a while.
+ */
+export async function sendWhatsAppReengagementReminder(
+  to: string,
+  patientName: string
+) {
+  if (!ACCESS_TOKEN || !process.env.WHATSAPP_PHONE_NUMBER_ID) {
+    console.error('WhatsApp credentials are not configured');
+    return;
+  }
+
+  const formattedPhone = to.startsWith('+')
+    ? to.substring(1)
+    : to.startsWith('40')
+      ? to
+      : `40${to}`;
+
+  try {
+    const response = await fetch(WHATSAPP_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${ACCESS_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to: formattedPhone,
+        type: 'template',
+        template: {
+          name: 'reengagement_reminder', // Must be approved in Meta Business Manager
+          language: { code: 'ro' },
+          components: [
+            {
+              type: 'body',
+              parameters: [{ type: 'text', text: patientName }],
+            },
+          ],
+        },
+      }),
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      console.error('Error sending WhatsApp re-engagement template:', data);
+    }
+    return data;
+  } catch (error) {
+    console.error('WhatsApp Re-engagement API call failed:', error);
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/webhook/whatsapp/reminders",
-      "schedule": "0 16 * * *"
+      "schedule": "0 16 * * 0-4,6"
     }
   ]
 }


### PR DESCRIPTION
This PR addresses two main requirements:
1. **Reminder System Adjustments**: The automated WhatsApp reminder cron job now runs from Sunday to Thursday for upcoming appointments (1 day in advance). On Saturdays, it identifies patients who haven't visited in exactly 6 months (180-187 days window) and have no future appointments, sending them a re-engagement message. Friday remains inactive for reminders.
2. **Calendar UI Fix**: Resolved an issue where clicking between different time slots on the calendar would not update the time in the AppointmentModal. This was achieved by adding useEffect hooks to synchronize internal state with props and ensuring the DialogProvider unmounts content upon closing.

Technical improvements include optimizing Supabase queries in the reminder route to batch process patient checks and adding concurrency management for re-engagement messages.

---
*PR created automatically by Jules for task [2944880440974022](https://jules.google.com/task/2944880440974022) started by @shiiro72*